### PR TITLE
将[TOC]替换成目录

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -290,7 +290,7 @@ class TableOfContents_Plugin implements Typecho_Plugin_Interface
         $toc .= "\n\n\n\n<!- toc end ->\n\n<hr>";
 
 
-        return str_replace('<!--TOC-->',$toc, $content);
+        return str_replace('<!--TOC-->',$toc, $html->save());
 
     }
 

--- a/css/toc_style.css
+++ b/css/toc_style.css
@@ -3,11 +3,12 @@
     border: 1px solid #ddd;
     background: #f8f8f8;
     line-height: 160%;
-    font-size: 12px;
+    font-size: 14px;
     width: 100%;
     position: relative;
     z-index: 900;
-    margin: 0 0 10px 10px;
+    margin: 20px 5px;
+    text-indent: 0;
 
 }
 
@@ -36,5 +37,4 @@
 
 @media (min-width:768px){
     .toc-index {
-        max-width: 30%;float: right;
     }}


### PR DESCRIPTION
在[TOC]标记的地方自动生成目录大概是很多markdown编辑器都有的功能。为了与他们维持一致，也是为了避免对不希望生成目录的文章生成目录，增加了这个功能。

出于美观考虑稍微修改了一些css。

Demo: http://terriex.com/index.php/archives/24/